### PR TITLE
Allow for EntityType filtering

### DIFF
--- a/src/DataProvider/DoctrineORMProvider.php
+++ b/src/DataProvider/DoctrineORMProvider.php
@@ -32,6 +32,11 @@ final class DoctrineORMProvider implements DataProviderInterface
         $qb->from($class, 'e');
 
         foreach ($filters as $field => $value) {
+            if(is_object($value)){
+                $qb->andWhere($qb->expr()->eq('e.' . $field, ':' . $field));
+                $qb->setParameter($field, $value);
+                continue;
+            }
             $qb->andWhere($qb->expr()->like('e.' . $field, ':' . $field));
             $qb->setParameter($field, "%$value%");
         }


### PR DESCRIPTION
Allows to use filters like this : 
->add('relation', EntityType::class, ['attr' => $this->stimulusSearchAttributes(), 'required' => false,
                'class' => RelationClass::class,
                'choice_label' => 'relation_label',
                'choice_value' => 'id',
                'placeholder' => 'All',
            ])